### PR TITLE
Fixes localStorage in Safari Private Window

### DIFF
--- a/common/layerSample.js
+++ b/common/layerSample.js
@@ -93,7 +93,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     button.innerHTML = '<i class="fa fa-spinner fa-pulse"></i>';
 
-    window.layerSample.appId = localStorage.layerAppId = appId;
+    window.layerSample.appId = appId;
+    try {
+       localStorage.layerAppId = appId;
+    } catch(e) {}
 
     var radios = div.getElementsByTagName('input');
     for (var i = 0; i < radios.length; i++) {


### PR DESCRIPTION
Safari throws errors on any attempt to write to localStorage in a private window.

All such attempts are now wrapped in try/catch blocks.